### PR TITLE
Remove GMDoc as it has been made closed-source

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@
 
 [Voronoi Pixels](https://github.com/XorDev/GMS-Voronoi-Pixels)
 
-[GMDoc Generator](https://github.com/kraifpatrik/gmdoc)
-
 [Xor's Shader Tutorials](https://xorshaders.weebly.com/)
 
 [Chunk Loading](https://github.com/tonystr/Reveen)


### PR DESCRIPTION
Title. Seems it happened quietly, but GMDoc has been removed from Patrik's GitHub and [GMDoc 2 has been released on the Marketplace for 109.99 USD](https://marketplace.yoyogames.com/assets/10014/gmdoc-2), pulling it outside of this list's scope (to my knowledge. There's no official statement but everything else here looks to be FOSS).