### PR TITLE
Removed Duplicate Entry (webm video player)

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -171,10 +171,6 @@
       "url": "https://www.youtube.com/playlist?list=PLYVea5brHS8YHECGPoEp4_gWU-k6nWzUy"
     },
     {
-      "title": ".webm Video Player",
-      "url": "https://marketplace.yoyogames.com/assets/9790/webm-player"
-    },
-    {
       "title": "JSONBabel (Translation)",
       "url": "https://comigo.itch.io/jsonbabel"
     },


### PR DESCRIPTION
I've removed this duplicate entry in the past, but I think the library file got formatted into json at some point and maybe my changes got lost there